### PR TITLE
New clients default to global configuration

### DIFF
--- a/lib/goodreads/client.rb
+++ b/lib/goodreads/client.rb
@@ -17,9 +17,9 @@ module Goodreads
     include Goodreads::Shelves
     include Goodreads::Authorized
     include Goodreads::Groups
-    
+
     attr_reader :api_key, :api_secret, :oauth_token
-    
+
     # Initialize a Goodreads::Client instance
     #
     # options[:api_key]     - Account API key
@@ -30,9 +30,9 @@ module Goodreads
       unless options.kind_of?(Hash)
         raise ArgumentError, "Options hash required."
       end
-      
-      @api_key    = options[:api_key]
-      @api_secret = options[:api_secret]
+
+      @api_key    = options[:api_key] || Goodreads.configuration[:api_key]
+      @api_secret = options[:api_secret] || Goodreads.configuration[:api_secret]
       @oauth_token = options[:oauth_token]
     end
   end


### PR DESCRIPTION
The client's initialize method ignored any settings defined in Goodreads.configuration. As expected, any settings in the constructor's hash will take precedence.
