### PR TITLE
Fixed bug with spaces in stub requests

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -152,9 +152,7 @@ describe 'Client' do
 
   describe '#author_by_name' do
     before do
-      # Spaces in author name pre-encoded to get past quirk in webmock
-      #
-      stub_with_key_get('/api/author_url', {:id => 'Orson%2BScott%2BCard'}, 'author_by_name.xml')
+      stub_with_key_get('/api/author_url', {:id => 'Orson Scott Card'}, 'author_by_name.xml')
     end
 
     it 'returns author details' do
@@ -236,7 +234,7 @@ describe 'Client' do
       shelf.books.first.book.title.should match /Your Money or Your Life/
     end
 
-    it "returns an ampty array when shelf is empty" do
+    it "returns an empty array when shelf is empty" do
       stub_with_key_get('/review/list/1.xml', {:shelf => 'to-read', :v => '2'}, 'empty.xml')
 
       shelf = client.shelf('1', 'to-read')


### PR DESCRIPTION
The webmock gem was [updated to version 1.11 yesterday](https://rubygems.org/gems/webmock), which was causing the most recent build on Travis CI to break. I ran bundle update on my local machine and recreated the error. A small change to the client spec -- removing URL-encoded spaces from the stub request for #author_by_name -- got the tests to pass again. You may want to require webmock 1.11 in the gemspec, since the current tests will fail in earlier versions.
