### PR TITLE
Updated version numbers for dependant gems

### DIFF
--- a/goodreads.gemspec
+++ b/goodreads.gemspec
@@ -11,14 +11,14 @@ Gem::Specification.new do |spec|
   spec.license     = "MIT"
   
   spec.add_development_dependency 'webmock',   '~> 1.11'
-  spec.add_development_dependency 'rake',      '~> 0.9'
+  spec.add_development_dependency 'rake',      '~> 10.0'
   spec.add_development_dependency 'rspec',     '~> 2.12'
   spec.add_development_dependency 'simplecov', '~> 0.7'
   spec.add_development_dependency 'yard',      '~> 0.6'
   
   spec.add_runtime_dependency 'rest-client',   '~> 1.6'
   spec.add_runtime_dependency 'hashie',        '~> 2.0'
-  spec.add_runtime_dependency 'activesupport', '~> 3.0'
+  spec.add_runtime_dependency 'activesupport', '~> 4.0'
   spec.add_runtime_dependency 'i18n',          '~> 0.5'
   spec.add_runtime_dependency 'oauth',         '~> 0.4'
 


### PR DESCRIPTION
I moved the rake dep up to 10 and the activesupport dep up to 4.  This enables
it to be used in a current version of rails.