### PR TITLE
Add 403 to request error cases

### DIFF
--- a/lib/goodreads/errors.rb
+++ b/lib/goodreads/errors.rb
@@ -1,6 +1,7 @@
 module Goodreads
   class Error              < StandardError; end
   class ConfigurationError < Error ; end
+  class Forbidden          < Error ; end
   class Unauthorized       < Error ; end
   class NotFound           < Error ; end
 end

--- a/lib/goodreads/request.rb
+++ b/lib/goodreads/request.rb
@@ -30,6 +30,8 @@ module Goodreads
             response.return!(request, result, &block)
           when 401
             raise Goodreads::Unauthorized
+          when 403
+            raise Goodreads::Forbidden
           when 404
             raise Goodreads::NotFound
         end


### PR DESCRIPTION
I'm not yet sure why I'm getting a 403 in a request to the API, but this PR should improve error handling.