### PR TITLE
Standard code style for tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Metrics/LineLength:
+  Max: 120

--- a/spec/authentication_spec.rb
+++ b/spec/authentication_spec.rb
@@ -4,21 +4,21 @@ describe 'Client' do
   before :each do
     Goodreads.reset_configuration
   end
-  
+
   it 'raises Goodreads::ConfigurationError if API key was not provided' do
     client = Goodreads::Client.new
-    
-    proc { client.book_by_isbn('0307463745') }.
-      should raise_error Goodreads::ConfigurationError, 'API key required.'
+
+    expect { client.book_by_isbn('0307463745') }
+      .to raise_error(Goodreads::ConfigurationError, 'API key required.')
   end
-    
+
   it 'raises Goodreads::Unauthorized if API key is not valid' do
-    client = Goodreads::Client.new(:api_key => 'INVALID_KEY')
-    
-    stub_request(:get, "http://www.goodreads.com/book/isbn?format=xml&isbn=054748250711&key=INVALID_KEY").
-      to_return(:status => 401)
-      
-    proc { client.book_by_isbn('054748250711') }.
-      should raise_error Goodreads::Unauthorized
+    client = Goodreads::Client.new(api_key: 'INVALID_KEY')
+
+    stub_request(:get, 'http://www.goodreads.com/book/isbn?format=xml&isbn=054748250711&key=INVALID_KEY')
+      .to_return(status: 401)
+
+    expect { client.book_by_isbn('054748250711') }
+      .to raise_error(Goodreads::Unauthorized)
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -2,62 +2,62 @@ require 'spec_helper'
 require 'oauth'
 
 describe 'Client' do
-  let(:client)  { Goodreads::Client.new(:api_key => 'SECRET_KEY') }
+  let(:client)  { Goodreads::Client.new(api_key: 'SECRET_KEY') }
   before(:each) { Goodreads.reset_configuration }
 
   describe '#new' do
     it 'requires an argument' do
-      expect { Goodreads::Client.new(nil) }.
-        to raise_error ArgumentError, "Options hash required."
+      expect { Goodreads::Client.new(nil) }
+        .to raise_error(ArgumentError, 'Options hash required.')
     end
 
     it 'requires a hash argument' do
-      expect { Goodreads::Client.new('foo') }.
-        to raise_error ArgumentError, "Options hash required."
+      expect { Goodreads::Client.new('foo') }
+        .to raise_error(ArgumentError, 'Options hash required.')
     end
   end
 
   describe '#book_by_isbn' do
-    before { stub_with_key_get('/book/isbn', {:isbn => '0307463745'}, 'book.xml') }
+    before { stub_with_key_get('/book/isbn', { isbn: '0307463745' }, 'book.xml') }
 
     it 'returns a book by isbn' do
       book = client.book_by_isbn('0307463745')
 
-      book.should respond_to :id
-      book.should respond_to :title
+      expect(book).to respond_to :id
+      expect(book).to respond_to :title
     end
 
     context 'when book does not exist' do
       before do
-        stub_request(:get, "http://www.goodreads.com/book/isbn?format=xml&isbn=123456789&key=SECRET_KEY").
-          to_return(:status => 404, :body => "", :headers => {}) 
+        stub_request(:get, 'http://www.goodreads.com/book/isbn?format=xml&isbn=123456789&key=SECRET_KEY')
+          .to_return(status: 404, body: '', headers: {})
       end
 
       it 'raises Goodreads::NotFound' do
-        expect { client.book_by_isbn('123456789') }.to raise_error Goodreads::NotFound
+        expect { client.book_by_isbn('123456789') }.to raise_error(Goodreads::NotFound)
       end
     end
   end
 
   describe '#search_books' do
-    before { stub_with_key_get('/search/index', {:q => 'Rework'}, 'search_books_by_name.xml') }
+    before { stub_with_key_get('/search/index', { q: 'Rework' }, 'search_books_by_name.xml') }
 
     it 'returns book search results' do
       result = client.search_books('Rework')
 
-      result.should be_a Hashie::Mash
-      result.should respond_to :query
-      result.should respond_to :total_results
-      result.should respond_to :results
-      result.results.should respond_to :work
-      result.query.should eq 'Rework'
-      result.results.work.size.should eq 3
-      result.results.work.first.id.should eq 6928276
+      expect(result).to be_a(Hashie::Mash)
+      expect(result).to respond_to(:query)
+      expect(result).to respond_to(:total_results)
+      expect(result).to respond_to(:results)
+      expect(result.results).to respond_to(:work)
+      expect(result.query).to eq('Rework')
+      expect(result.results.work.size).to eq(3)
+      expect(result.results.work.first.id).to eq(6_928_276)
     end
   end
 
   describe '#book' do
-    before { stub_with_key_get('/book/show', {:id => '6732019'}, 'book.xml') }
+    before { stub_with_key_get('/book/show', { id: '6732019' }, 'book.xml') }
 
     it 'returns a book by goodreads id' do
       expect { client.book('6732019') }.not_to raise_error
@@ -65,7 +65,7 @@ describe 'Client' do
   end
 
   describe '#book_by_title' do
-    before { stub_with_key_get('/book/title', {:title => 'Rework'}, 'book.xml') }
+    before { stub_with_key_get('/book/title', { title: 'Rework' }, 'book.xml') }
 
     it 'returns a book by title' do
       expect { client.book_by_title('Rework') }.not_to raise_error
@@ -78,40 +78,40 @@ describe 'Client' do
     it 'returns recent reviews' do
       reviews = client.recent_reviews
 
-      reviews.should be_an Array
-      reviews.should_not be_empty
-      reviews.first.should respond_to :id
+      expect(reviews).to be_an(Array)
+      expect(reviews).to_not be_empty
+      expect(reviews.first).to respond_to(:id)
     end
 
     context 'with :skip_cropped => true' do
       before { stub_with_key_get('/review/recent_reviews', {}, 'recent_reviews.xml') }
-  
+
       it 'returns only full reviews' do
-        reviews = client.recent_reviews(:skip_cropped => true)
-        reviews.should be_an Array
-        reviews.should_not be_empty
+        reviews = client.recent_reviews(skip_cropped: true)
+        expect(reviews).to be_an(Array)
+        expect(reviews).to_not be_empty
       end
     end
   end
 
   describe '#review' do
-    before { stub_with_key_get('/review/show', {:id => '166204831'}, 'review.xml') }
+    before { stub_with_key_get('/review/show', { id: '166204831' }, 'review.xml') }
 
     it 'returns review details' do
       review = client.review('166204831')
 
-      review.should be_a Hashie::Mash
-      review.id.should eq '166204831'
+      expect(review).to be_a(Hashie::Mash)
+      expect(review.id).to eq('166204831')
     end
 
     context 'when review does not exist' do
       before do
-        stub_request(:get, "http://www.goodreads.com/review/show?format=xml&id=12345&key=SECRET_KEY").
-          to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:get, 'http://www.goodreads.com/review/show?format=xml&id=12345&key=SECRET_KEY')
+          .to_return(status: 404, body: '', headers: {})
       end
 
       it 'raises Goodreads::NotFound' do
-        expect { client.review('12345') }.to raise_error Goodreads::NotFound
+        expect { client.review('12345') }.to raise_error(Goodreads::NotFound)
       end
     end
   end
@@ -121,213 +121,217 @@ describe 'Client' do
     let(:user_id) { '5076380' }
     let(:shelf) { 'to-read' }
 
-    before { stub_with_key_get('/review/list', {:v => '2', :id => user_id, :shelf => shelf}, response_fixture) }
+    before { stub_with_key_get('/review/list', { v: '2', id: user_id, shelf: shelf }, response_fixture) }
     let(:response_fixture) { 'reviews.xml' }
 
     it 'returns a list of reviews' do
-      subject.should be_a Array
-      subject.count.should eq 2
-      subject.first.should be_a Hashie::Mash
-      subject.first.keys.should include(*['book', 'rating', 'started_at', 'read_at'])
-      subject.map(&:id).should eq(['1371624338', '1371623371'])
+      expect(subject).to be_an(Array)
+      expect(subject.count).to eq(2)
+      expect(subject.first).to be_a(Hashie::Mash)
+      expect(subject.first.keys).to include(*%w(book rating started_at read_at))
+      expect(subject.map(&:id)).to eq(%w(1371624338 1371623371))
     end
 
     context 'when there are no more reviews' do
       let(:response_fixture) { 'reviews_empty.xml' }
 
       it 'returns an empty array' do
-        subject.should be_a Array
-        subject.count.should eq 0
+        expect(subject).to be_an(Array)
+        expect(subject.count).to eq(0)
       end
     end
 
     context 'when user does not exist' do
       before do
-        stub_request(:get, "http://www.goodreads.com/review/list?v=2&format=xml&id=#{user_id}&key=SECRET_KEY&shelf=#{shelf}").
-          to_return(:status => 404, :body => "", :headers => {})
+        url_params = "v=2&format=xml&id=#{user_id}&key=SECRET_KEY&shelf=#{shelf}"
+        stub_request(:get, "http://www.goodreads.com/review/list?#{url_params}")
+          .to_return(status: 404, body: '', headers: {})
       end
 
       it 'raises Goodreads::NotFound' do
-        expect { subject }.to raise_error Goodreads::NotFound
+        expect { subject }.to raise_error(Goodreads::NotFound)
       end
     end
   end
 
   describe '#author' do
-    before { stub_with_key_get('/author/show', {:id => '18541'}, 'author.xml') }
+    before { stub_with_key_get('/author/show', { id: '18541' }, 'author.xml') }
 
     it 'returns author details' do
       author = client.author('18541')
 
-      author.should be_a Hashie::Mash
-      author.id.should eq '18541'
-      author.name.should eq "Tim O'Reilly"
-      author.link.should eq 'http://www.goodreads.com/author/show/18541.Tim_O_Reilly'
-      author.fans_count.should eq 109
-      author.image_url.should eq 'http://photo.goodreads.com/authors/1199698411p5/18541.jpg'
-      author.small_image_url.should eq 'http://photo.goodreads.com/authors/1199698411p2/18541.jpg'
-      author.about.should eq '' 
-      author.influences.should eq ''
-      author.works_count.should eq '34'
-      author.gender.should eq 'male'
-      author.hometown.should eq 'Cork'
-      author.born_at.should eq '1954/06/06'
-      author.died_at.should be_nil
+      expect(author).to be_a(Hashie::Mash)
+      expect(author.id).to eq('18541')
+      expect(author.name).to eq("Tim O'Reilly")
+      expect(author.link).to eq('http://www.goodreads.com/author/show/18541.Tim_O_Reilly')
+      expect(author.fans_count).to eq(109)
+      expect(author.image_url).to eq('http://photo.goodreads.com/authors/1199698411p5/18541.jpg')
+      expect(author.small_image_url).to eq('http://photo.goodreads.com/authors/1199698411p2/18541.jpg')
+      expect(author.about).to eq('')
+      expect(author.influences).to eq('')
+      expect(author.works_count).to eq('34')
+      expect(author.gender).to eq('male')
+      expect(author.hometown).to eq('Cork')
+      expect(author.born_at).to eq('1954/06/06')
+      expect(author.died_at).to be_nil
     end
 
     context 'when author does not exist' do
       before do
-        stub_request(:get, "http://www.goodreads.com/author/show?format=xml&id=12345&key=SECRET_KEY").
-          to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:get, 'http://www.goodreads.com/author/show?format=xml&id=12345&key=SECRET_KEY')
+          .to_return(status: 404, body: '', headers: {})
       end
 
       it 'raises Goodreads::NotFound' do
-        expect { client.author('12345') }.to raise_error Goodreads::NotFound
+        expect { client.author('12345') }.to raise_error(Goodreads::NotFound)
       end
     end
   end
 
   describe '#author_by_name' do
     before do
-      stub_with_key_get('/api/author_url/Orson%20Scott%20Card', {:id => 'Orson Scott Card'}, 'author_by_name.xml')
+      stub_with_key_get('/api/author_url/Orson%20Scott%20Card', { id: 'Orson Scott Card' }, 'author_by_name.xml')
     end
 
     it 'returns author details' do
       author = client.author_by_name('Orson Scott Card')
 
-      author.should be_a Hashie::Mash
-      author.id.should eq   '589'
-      author.name.should eq 'Orson Scott Card'
-      author.link.should eq 'http://www.goodreads.com/author/show/589.Orson_Scott_Card?utm_medium=api&utm_source=author_link'
+      expect(author).to be_a(Hashie::Mash)
+      expect(author.id).to eq('589')
+      expect(author.name).to eq('Orson Scott Card')
+      expect(author.link).to eq('http://www.goodreads.com/author/show/589.Orson_Scott_Card?utm_medium=api&utm_source=author_link')
     end
   end
 
   describe '#user' do
-    before { stub_with_key_get('/user/show', {:id => '878044'}, 'user.xml') }
+    before { stub_with_key_get('/user/show', { id: '878044' }, 'user.xml') }
 
     it 'returns user details' do
       user = client.user('878044')
 
-      user.should be_a Hashie::Mash
-      user.id.should eq '878044'
-      user.name.should eq 'Jan'
-      user.user_name.should eq 'janmt'
+      expect(user).to be_a(Hashie::Mash)
+      expect(user.id).to eq('878044')
+      expect(user.name).to eq('Jan')
+      expect(user.user_name).to eq('janmt')
     end
 
     context 'when user does not exist' do
       before do
-        stub_request(:get, "http://www.goodreads.com/user/show?format=xml&id=12345&key=SECRET_KEY").
-          to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:get, 'http://www.goodreads.com/user/show?format=xml&id=12345&key=SECRET_KEY')
+          .to_return(status: 404, body: '', headers: {})
       end
 
       it 'raises Goodreads::NotFound' do
-        expect { client.user('12345') }.to raise_error Goodreads::NotFound
+        expect { client.user('12345') }.to raise_error(Goodreads::NotFound)
       end
     end
   end
 
   describe '#friends' do
-    before { client.stub(:oauth_request).and_return(Hash.from_xml(fixture('friends.xml'))['GoodreadsResponse']) }
+    before do
+      allow(client).to receive(:oauth_request)
+        .and_return(Hash.from_xml(fixture('friends.xml'))['GoodreadsResponse'])
+    end
 
     it 'returns friend details' do
       friends = client.friends('878044')
 
-      friends.should be_an_instance_of Hashie::Mash
-      friends.should respond_to :user
-      friends.user.size.should eq friends.end.to_i
-      friends.user.first.should respond_to :name
+      expect(friends).to be_an_instance_of(Hashie::Mash)
+      expect(friends).to respond_to(:user)
+      expect(friends.user.size).to eq(friends.end.to_i)
+      expect(friends.user.first).to respond_to(:name)
     end
   end
 
   describe '#shelf' do
     it "returns list of books for a user's specified shelf" do
-      stub_with_key_get('/review/list/1.xml', {:shelf => 'to-read', :v => '2'}, 'to-read.xml')
+      stub_with_key_get('/review/list/1.xml', { shelf: 'to-read', v: '2' }, 'to-read.xml')
 
       shelf = client.shelf('1', 'to-read')
 
-      shelf.should respond_to :start
-      shelf.should respond_to :end
-      shelf.should respond_to :total
-      shelf.should respond_to :books
+      expect(shelf).to respond_to(:start)
+      expect(shelf).to respond_to(:end)
+      expect(shelf).to respond_to(:total)
+      expect(shelf).to respond_to(:books)
 
-      shelf.start.should eq 1
-      shelf.end.should eq 20
-      shelf.total.should eq 40
-      shelf.books.length.should eq 20
-      shelf.books.first.id.should eq '45590939'
-      shelf.books.first.book.title.strip.should eq 'The Demon-Haunted World: Science as a Candle in the Dark'
+      expect(shelf.start).to eq(1)
+      expect(shelf.end).to eq(20)
+      expect(shelf.total).to eq(40)
+      expect(shelf.books.length).to eq(20)
+      expect(shelf.books.first.id).to eq('45590939')
+      expect(shelf.books.first.book.title.strip).to eq('The Demon-Haunted World: Science as a Candle in the Dark')
     end
 
     it "paginates book lists from a user's shelf" do
-      stub_with_key_get('/review/list/1.xml', {:shelf => 'to-read', :v => '2', :page => '2'}, 'to-read-p2.xml')
+      stub_with_key_get('/review/list/1.xml', { shelf: 'to-read', v: '2', page: '2' }, 'to-read-p2.xml')
 
-      shelf = client.shelf('1', 'to-read', :page => 2)
+      shelf = client.shelf('1', 'to-read', page: 2)
 
-      shelf.start.should eq 21
-      shelf.end.should eq 40
-      shelf.total.should eq 40
-      shelf.books.length.should eq 20
-      shelf.books.first.id.should eq '107804211'
-      shelf.books.first.book.title.should match /Your Money or Your Life/
+      expect(shelf.start).to eq(21)
+      expect(shelf.end).to eq(40)
+      expect(shelf.total).to eq(40)
+      expect(shelf.books.length).to eq(20)
+      expect(shelf.books.first.id).to eq('107804211')
+      expect(shelf.books.first.book.title).to match(/Your Money or Your Life/)
     end
 
-    it "returns an empty array when shelf is empty" do
-      stub_with_key_get('/review/list/1.xml', {:shelf => 'to-read', :v => '2'}, 'empty.xml')
+    it 'returns an empty array when shelf is empty' do
+      stub_with_key_get('/review/list/1.xml', { shelf: 'to-read', v: '2' }, 'empty.xml')
 
       shelf = client.shelf('1', 'to-read')
 
-      shelf.start.should eq 0
-      shelf.end.should eq 0
-      shelf.total.should eq 0
-      shelf.books.length.should eq 0
+      expect(shelf.start).to eq(0)
+      expect(shelf.end).to eq(0)
+      expect(shelf.total).to eq(0)
+      expect(shelf.books.length).to eq(0)
     end
   end
 
   describe '#user_id' do
-    let(:consumer) { OAuth::Consumer.new('API_KEY', 'SECRET_KEY', :site => 'http://www.goodreads.com') }
+    let(:consumer) { OAuth::Consumer.new('API_KEY', 'SECRET_KEY', site: 'http://www.goodreads.com') }
     let(:token)    { OAuth::AccessToken.new(consumer, 'ACCESS_TOKEN', 'ACCESS_SECRET') }
 
     before do
-      stub_request(:get, "http://www.goodreads.com/api/auth_user").
-        to_return(:status => 200, :body => fixture('oauth_response.xml'), :headers => {})
+      stub_request(:get, 'http://www.goodreads.com/api/auth_user')
+        .to_return(status: 200, body: fixture('oauth_response.xml'), headers: {})
     end
 
     it 'returns id of the user with oauth authentication' do
-      client = Goodreads::Client.new(:api_key => 'SECRET_KEY', :oauth_token => token)
-      client.user_id.should eq '2003928'
+      client = Goodreads::Client.new(api_key: 'SECRET_KEY', oauth_token: token)
+      expect(client.user_id).to eq('2003928')
     end
   end
 
   describe '#group' do
-    before { stub_with_key_get('/group/show', {:id => '1'}, 'group.xml') }
+    before { stub_with_key_get('/group/show', { id: '1' }, 'group.xml') }
 
-    it "returns group details" do
+    it 'returns group details' do
       group = client.group('1')
-    
-      group.should be_a Hashie::Mash
-      group.id.should eq '1'
-      group.title.should eq 'Goodreads Feedback'
-      group.access.should eq 'public'
-      group.location.should eq ''
-      group.category.should eq 'Business'
-      group.subcategory.should eq 'Companies'
-      group.group_users_count.should eq '10335'
+
+      expect(group).to be_a(Hashie::Mash)
+      expect(group.id).to eq('1')
+      expect(group.title).to eq('Goodreads Feedback')
+      expect(group.access).to eq('public')
+      expect(group.location).to eq('')
+      expect(group.category).to eq('Business')
+      expect(group.subcategory).to eq('Companies')
+      expect(group.group_users_count).to eq('10335')
     end
   end
 
   describe '#group_list' do
-    before { stub_with_key_get('/group/list', {:id => '1', :sort => 'my_activity'}, 'group_list.xml') }
+    before { stub_with_key_get('/group/list', { id: '1', sort: 'my_activity' }, 'group_list.xml') }
 
-    it "returns groups a given user is a member of" do
+    it 'returns groups a given user is a member of' do
       group_list = client.group_list('1')
 
-      group_list.should be_a Hashie::Mash
-      group_list.total.should eq '107'
-      group_list.group.count.should eq 50
-      group_list.group[0].id.should eq '1'
-      group_list.group[0].title.should eq 'Goodreads Feedback'
-      group_list.group[1].id.should eq '220'
-      group_list.group[2].users_count.should eq '530'
+      expect(group_list).to be_a(Hashie::Mash)
+      expect(group_list.total).to eq('107')
+      expect(group_list.group.count).to eq(50)
+      expect(group_list.group[0].id).to eq('1')
+      expect(group_list.group[0].title).to eq('Goodreads Feedback')
+      expect(group_list.group[1].id).to eq('220')
+      expect(group_list.group[2].users_count).to eq('530')
     end
   end
 end

--- a/spec/goodreads_spec.rb
+++ b/spec/goodreads_spec.rb
@@ -3,52 +3,52 @@ require 'spec_helper'
 describe 'Goodreads' do
   describe '.new' do
     it 'returns a new client instance' do
-      Goodreads.new.should be_a Goodreads::Client
+      expect(Goodreads.new).to be_a(Goodreads::Client)
     end
   end
 
   describe '.configure' do
     it 'sets a global configuration options' do
-      r = Goodreads.configure(:api_key => 'FOO', :api_secret => 'BAR')
-      r.should be_a Hash
-      r.should have_key(:api_key)
-      r.should have_key(:api_secret)
-      r[:api_key].should eql('FOO')
-      r[:api_secret].should eql('BAR')
+      config = Goodreads.configure(api_key: 'FOO', api_secret: 'BAR')
+      expect(config).to be_a(Hash)
+      expect(config).to have_key(:api_key)
+      expect(config).to have_key(:api_secret)
+      expect(config[:api_key]).to eql('FOO')
+      expect(config[:api_secret]).to eql('BAR')
     end
 
     it 'raises ConfigurationError on invalid config parameter' do
-      proc { Goodreads.configure(nil) }.
-        should raise_error(ArgumentError, "Options hash required.")
+      expect { Goodreads.configure(nil) }
+        .to raise_error(ArgumentError, 'Options hash required.')
 
-      proc { Goodreads.configure('foo') }.
-        should raise_error ArgumentError, "Options hash required."
+      expect { Goodreads.configure('foo') }
+        .to raise_error(ArgumentError, 'Options hash required.')
     end
   end
 
   describe '.configuration' do
     before do
-      Goodreads.configure(:api_key => 'FOO', :api_secret => 'BAR')
+      Goodreads.configure(api_key: 'FOO', api_secret: 'BAR')
     end
 
     it 'returns global configuration options' do
-      r = Goodreads.configuration
-      r.should be_a Hash
-      r.should have_key(:api_key)
-      r.should have_key(:api_secret)
-      r[:api_key].should eql('FOO')
-      r[:api_secret].should eql('BAR')
+      config = Goodreads.configuration
+      expect(config).to be_a(Hash)
+      expect(config).to have_key(:api_key)
+      expect(config).to have_key(:api_secret)
+      expect(config[:api_key]).to eql('FOO')
+      expect(config[:api_secret]).to eql('BAR')
     end
   end
 
   describe '.reset_configuration' do
     before do
-      Goodreads.configure(:api_key => 'FOO', :api_secret => 'BAR')
+      Goodreads.configure(api_key: 'FOO', api_secret: 'BAR')
     end
 
     it 'resets global configuration options' do
       Goodreads.reset_configuration
-      Goodreads.configuration.should eql({})
+      expect(Goodreads.configuration).to eql({})
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-$:.unshift File.expand_path("../..", __FILE__)
+$LOAD_PATH.unshift(File.expand_path('../..', __FILE__))
 
 require 'simplecov'
 
 SimpleCov.start do
-  add_filter "spec/"
-  add_filter ".bundle"
+  add_filter 'spec/'
+  add_filter '.bundle'
 end
 
 require 'goodreads'
@@ -13,11 +13,11 @@ require 'webmock/rspec'
 
 def stub_get(path, params, fixture_name)
   params[:format] = 'xml'
-  stub_request(:get, api_url(path)).
-    with(:query => params).
-    to_return(
-      :status => 200,
-      :body => fixture(fixture_name)
+  stub_request(:get, api_url(path))
+    .with(query: params)
+    .to_return(
+      status: 200,
+      body: fixture(fixture_name)
     )
 end
 
@@ -26,8 +26,8 @@ def stub_with_key_get(path, params, fixture_name)
   stub_get(path, params, fixture_name)
 end
 
-def fixture_path(file=nil)
-  path = File.expand_path("../fixtures", __FILE__)
+def fixture_path(file = nil)
+  path = File.expand_path('../fixtures', __FILE__)
   file.nil? ? path : File.join(path, file)
 end
 


### PR DESCRIPTION
* Introduced [rubocop](https://github.com/bbatsov/rubocop) config
* Applied almost default rubocop style guide for `spec/`
* Fixed deprecated rspec usage (`expect` instead of `should`, `allow` instead of `stub`)