### PR TITLE
request: Use HTTPS for API requests

### DIFF
--- a/lib/goodreads/request.rb
+++ b/lib/goodreads/request.rb
@@ -4,7 +4,7 @@ require "hashie"
 
 module Goodreads
   module Request
-    API_URL    = "http://www.goodreads.com"
+    API_URL    = "https://www.goodreads.com"
     API_FORMAT = "xml"
 
     protected


### PR DESCRIPTION
This just changes the API URL to use HTTPS, instead of plain old HTTP. The Goodreads API has supported HTTPS for a while now, so this shouldn't break anything.

Thanks for the library, and let me know if you'd like me to add anything else to this PR :smile: 