### PR TITLE
Support API methods for manipulating user reviews

### DIFF
--- a/lib/goodreads/client.rb
+++ b/lib/goodreads/client.rb
@@ -35,5 +35,14 @@ module Goodreads
       @api_secret = options[:api_secret] || Goodreads.configuration[:api_secret]
       @oauth_token = options[:oauth_token]
     end
+
+    # Return if this client is configured with OAuth credentials
+    # for a single user
+    #
+    # False when client is instantiated with an api_key and secret,
+    # true when client is instantiated with an oauth_token
+    def oauth_configured?
+      !oauth_token.nil?
+    end
   end
 end

--- a/lib/goodreads/client/reviews.rb
+++ b/lib/goodreads/client/reviews.rb
@@ -31,5 +31,11 @@ module Goodreads
         []
       end
     end
+
+    # Get a user's review for a given book
+    def user_review(user_id, book_id, params = {})
+      data = request('/review/show_by_user_and_book.xml', params.merge(v: "2", user_id: user_id, book_id: book_id))
+      Hashie::Mash.new(data["review"])
+    end
   end
 end

--- a/lib/goodreads/client/reviews.rb
+++ b/lib/goodreads/client/reviews.rb
@@ -37,5 +37,29 @@ module Goodreads
       data = request('/review/show_by_user_and_book.xml', params.merge(v: "2", user_id: user_id, book_id: book_id))
       Hashie::Mash.new(data["review"])
     end
+
+    # Add review for a book
+    #
+    # Params can include :review, :rating, and :shelf
+    #
+    # review: text of the review (optional)
+    # rating: rating (0-5) (optional, default is 0 (no rating))
+    # shelf: Name of shelf to add book to (optional, must exist, see: shelves.list)
+    #
+    # Note that Goodreads API documentation says that this endpoint accepts
+    # the read_at parameter but it does not appear to work as of 2018-06.
+    def create_review(book_id, params = {})
+      params = params.merge(book_id: book_id, v: "2")
+
+      params[:read_at] = params[:read_at].strftime('%Y-%m-%d') if params[:read_at].is_a?(Time)
+
+      params[:'review[review]'] = params.delete(:review) if params[:review]
+      params[:'review[rating]'] = params.delete(:rating) if params[:rating]
+      params[:'review[read_at]'] = params.delete(:read_at) if params[:read_at]
+
+      data = oauth_request_method(:post, '/review.xml', params)
+
+      Hashie::Mash.new(data["review"])
+    end
   end
 end

--- a/lib/goodreads/client/reviews.rb
+++ b/lib/goodreads/client/reviews.rb
@@ -61,5 +61,31 @@ module Goodreads
 
       Hashie::Mash.new(data["review"])
     end
+
+    # Edit review for a book
+    #
+    # Params can include :review, :rating, :read_at and :shelf, and :finished
+    #
+    # review: text of the review (optional)
+    # rating: rating (0-5) (optional, default is 0 (no rating))
+    # shelf: Name of shelf to add book to (optional, must exist, see: shelves.list)
+    # read_at: Time object or String in YYYY-MM-DD format (optional)
+    # finished: true to mark finished reading (optional)
+    # shelf: Name of shelf to add book to (optional, must exist, see: shelves.list)
+    def edit_review(review_id, params = {})
+      params = params.merge(v: "2")
+
+      params[:read_at] = params[:read_at].strftime('%Y-%m-%d') if params[:read_at].is_a?(Time)
+
+      params[:'review[review]'] = params.delete(:review) if params[:review]
+      params[:'review[rating]'] = params.delete(:rating) if params[:rating]
+      params[:'review[read_at]'] = params.delete(:read_at) if params[:read_at]
+
+      # Documentation says that you should use HTTP PUT, but API returns
+      # 401 Unauthorized when PUT is used instead of POST
+      data = oauth_request_method(:post, "/review/#{review_id}.xml", params)
+
+      Hashie::Mash.new(data["review"])
+    end
   end
 end

--- a/lib/goodreads/request.rb
+++ b/lib/goodreads/request.rb
@@ -58,7 +58,7 @@ module Goodreads
 
       headers = { "Accept" => "application/xml" }
 
-      resp = if http_method == :get
+      resp = if http_method == :get || http_method == :delete
         if params
           url_params = params.map { |k, v| "#{k}=#{v}" }.join("&")
           path = "#{path}?#{url_params}"

--- a/lib/goodreads/request.rb
+++ b/lib/goodreads/request.rb
@@ -9,12 +9,26 @@ module Goodreads
 
     protected
 
-    # Perform an API request
+    # Perform an API request using API key or OAuth token
     #
     # path   - Request path
     # params - Parameters hash
     #
+    # Will make a request with the configured API key (application
+    # authentication) or OAuth token (user authentication) if available.
     def request(path, params = {})
+      if oauth_configured?
+        oauth_request(path, params)
+      else
+        http_request(path, params)
+      end
+    end
+
+    # Perform an API request using API key
+    #
+    # path   - Request path
+    # params - Parameters hash
+    def http_request(path, params)
       token = api_key || Goodreads.configuration[:api_key]
 
       fail(Goodreads::ConfigurationError, "API key required.") if token.nil?
@@ -43,7 +57,7 @@ module Goodreads
     # path   - Request path
     # params - Parameters hash
     #
-    def oauth_request(path, params = nil)
+    def oauth_request(path, params = {})
       oauth_request_method(:get, path, params)
     end
 
@@ -53,7 +67,7 @@ module Goodreads
     # path   - Request path
     # params - Parameters hash
     #
-    def oauth_request_method(http_method, path, params = nil)
+    def oauth_request_method(http_method, path, params = {})
       fail "OAuth access token required!" unless @oauth_token
 
       headers = { "Accept" => "application/xml" }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -377,6 +377,39 @@ describe "Client" do
     end
   end
 
+  describe "#create_review" do
+    let(:consumer) { OAuth::Consumer.new("API_KEY", "SECRET_KEY", site: "https://www.goodreads.com") }
+    let(:token)    { OAuth::AccessToken.new(consumer, "ACCESS_TOKEN", "ACCESS_SECRET") }
+
+    it "creates a new review for a book" do
+      stub_request(:post, "https://www.goodreads.com/review.xml")
+        .with(:body => {
+          "book_id"=>"456",
+          "review" => {
+            "rating" => "3",
+            "review" => "Good book.",
+            "read_at" => "2018-01-02",
+          },
+          "shelf" => "read",
+          "v"=>"2",
+        })
+        .to_return(status: 201, body: fixture("review_create.xml"))
+
+      client = Goodreads::Client.new(api_key: "SECRET_KEY", oauth_token: token)
+      review = client.create_review(456, {
+        :review => "Good book.",
+        :rating => 3,
+        :read_at => Time.parse('2018-01-02'),
+        :shelf => "read",
+      })
+
+      expect(review.id).to eq("67890")
+      expect(review.book.id).to eq(456)
+      expect(review.rating).to eq("3")
+      expect(review.body).to eq("Good book.")
+    end
+  end
+
   describe "#user_id" do
     let(:consumer) { OAuth::Consumer.new("API_KEY", "SECRET_KEY", site: "https://www.goodreads.com") }
     let(:token)    { OAuth::AccessToken.new(consumer, "ACCESS_TOKEN", "ACCESS_SECRET") }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -410,6 +410,40 @@ describe "Client" do
     end
   end
 
+  describe "#edit_review" do
+    let(:consumer) { OAuth::Consumer.new("API_KEY", "SECRET_KEY", site: "https://www.goodreads.com") }
+    let(:token)    { OAuth::AccessToken.new(consumer, "ACCESS_TOKEN", "ACCESS_SECRET") }
+
+    it "creates a new review for a book" do
+      stub_request(:post, "https://www.goodreads.com/review/67890.xml")
+        .with(:body => {
+          "finished" => "true",
+          "review" => {
+            "rating" => "5",
+            "review" => "Fantastic book.",
+            "read_at" => "2018-04-15",
+          },
+          "shelf" => "read",
+          "v"=>"2",
+        })
+        .to_return(status: 201, body: fixture("review_update.xml"))
+
+      client = Goodreads::Client.new(api_key: "SECRET_KEY", oauth_token: token)
+      review = client.edit_review(67890, {
+        :finished => true,
+        :review => "Fantastic book.",
+        :rating => 5,
+        :read_at => Time.parse('2018-04-15'),
+        :shelf => "read",
+      })
+
+      expect(review.id).to eq("67890")
+      expect(review.book.id).to eq(456)
+      expect(review.rating).to eq("5")
+      expect(review.body).to eq("Fantastic book.")
+    end
+  end
+
   describe "#user_id" do
     let(:consumer) { OAuth::Consumer.new("API_KEY", "SECRET_KEY", site: "https://www.goodreads.com") }
     let(:token)    { OAuth::AccessToken.new(consumer, "ACCESS_TOKEN", "ACCESS_SECRET") }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -17,6 +17,38 @@ describe "Client" do
     end
   end
 
+  describe "#oauth_configured?" do
+    it "is true when OAuth token provided to constructor" do
+      client = Goodreads::Client.new(oauth_token: "a token")
+      expect(client.oauth_configured?).to be true
+    end
+
+    it "is true when oauth token is not provided to constructor" do
+      client = Goodreads::Client.new(api_key: "SECRET_KEY")
+      expect(client.oauth_configured?).to be false
+    end
+  end
+
+  describe "#request" do
+    it "makes an OAuth request if client has an oauth_token" do
+      oauth_token = double
+      response = double
+      allow(oauth_token).to receive(:request)
+        .and_return(response)
+      allow(response).to receive(:body)
+        .and_return(fixture("book.xml"))
+
+      client = Goodreads::Client.new(oauth_token: oauth_token)
+      client.book(123)
+    end
+
+    it "makes an HTTP request with token if client does have an oauth_token" do
+      allow(client).to receive(:http_request)
+        .and_return(Hash.from_xml(fixture("book.xml"))["GoodreadsResponse"])
+      client.book(123)
+    end
+  end
+
   describe "#book_by_isbn" do
     before { stub_with_key_get("/book/isbn", { isbn: "0307463745" }, "book.xml") }
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -186,6 +186,26 @@ describe "Client" do
     end
   end
 
+  describe "#user_review" do
+    let(:consumer) { OAuth::Consumer.new("API_KEY", "SECRET_KEY", site: "https://www.goodreads.com") }
+    let(:token)    { OAuth::AccessToken.new(consumer, "ACCESS_TOKEN", "ACCESS_SECRET") }
+
+    it "returns a user's existing review" do
+      stub_request(:get, "https://www.goodreads.com/review/show_by_user_and_book.xml?book_id=50&user_id=1&v=2")
+        .to_return(status: 200, body: fixture("review_show_by_user_and_book.xml"))
+
+      client = Goodreads::Client.new(api_key: "SECRET_KEY", oauth_token: token)
+      review = client.user_review(1, 50)
+
+      expect(review.id).to eq("21")
+      expect(review.book.id).to eq(50)
+
+      expect(review.rating).to eq("5")
+      expect(review.body.strip).to eq("")
+      expect(review.date_added).to eq("Tue Aug 29 11:20:01 -0700 2006")
+    end
+  end
+
   describe "#author" do
     before { stub_with_key_get("/author/show", { id: "18541" }, "author.xml") }
 

--- a/spec/fixtures/review_create.xml
+++ b/spec/fixtures/review_create.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GoodreadsResponse>
+  <Request>
+    <authentication>true</authentication>
+    <key><![CDATA[SECRET_KEY]]></key>
+    <method><![CDATA[review_create]]></method>
+  </Request>
+
+      <review>
+  <id>67890</id>
+
+  <user>
+    <id>123456</id>
+    <uri>kca://profile:goodreads/A25C3Y1SBGK9NK</uri>
+    <name>Test</name>
+    <display_name>Test User</display_name>
+
+    <location>Lafayette, CA</location>
+
+    <link><![CDATA[https://www.goodreads.com/user/show/123456-test-user]]></link>
+
+    <image_url><![CDATA[https://s.gr-assets.com/assets/nophoto/user/u_111x148-9394ebedbb3c6c218f64be9549657029.png]]></image_url>
+    <small_image_url><![CDATA[https://s.gr-assets.com/assets/nophoto/user/u_50x66-632230dc9882b4352d753eedf9396530.png]]></small_image_url>
+    <has_image>false</has_image>
+
+  </user>
+
+    <book>
+  <id type="integer">456</id>
+  <isbn>0195138570</isbn>
+  <isbn13>9780195138573</isbn13>
+  <text_reviews_count type="integer">11</text_reviews_count>
+  <uri>kca://book/amzn1.gr.book.v1.oHwPZrciugo6gPSINsfCaw</uri>
+  <title>Mindware: An Introduction to the Philosophy of Cognitive Science</title>
+  <title_without_series>Mindware: An Introduction to the Philosophy of Cognitive Science</title_without_series>
+  <image_url>https://s.gr-assets.com/assets/nophoto/book/111x148-bcc042a9c91a29c1d680899eff700a03.png</image_url>
+  <small_image_url>https://s.gr-assets.com/assets/nophoto/book/50x75-a91bf249278a81aabab721ef782c4a74.png</small_image_url>
+  <large_image_url/>
+  <link>https://www.goodreads.com/book/show/456.Mindware</link>
+  <num_pages>224</num_pages>
+  <format>Paperback</format>
+  <edition_information>1st edition</edition_information>
+  <publisher>Oxford University Press, USA</publisher>
+  <publication_day>21</publication_day>
+  <publication_year>2000</publication_year>
+  <publication_month>12</publication_month>
+  <average_rating>3.78</average_rating>
+  <ratings_count>210</ratings_count>
+  <description>&lt;p&gt;&lt;i&gt;Mindware&lt;/i&gt; is an introductory text with a difference. In eight short chapters it tells a story and invites the reader to join in some up-to-the-minute conceptual discussion of the key issues, problems, and opportunities in cognitive science. The story is about the search for a cognitive scientific understanding of mind. It is presented as a no-holds-barred journey from early work in Artificial Intelligence, through connectionist (artificial neural network) counter-visions, and onto neuroscience artificial life, dynamics and robotics. The journey ends with some wide-ranging and provacative speculation about the role of technology and the changing nature of the human mind itself.&lt;br /&gt;Each chapter is organized as an initial sketch of a research program or theme, followed by a substantial discussion section in which specific problems and issues (both familiear and cutting-edge) are raised and pursued. Discussion topics include mental causation, the hardware/software distinction, the relations between life and mind, the nature of perception, cognition and action, and the continuity (or otherwise) of high-level human intelligence with other forms of adaptive response. Classic topics are treated alongside the newer ones in an integrated treatment of the various discussions. The sketches and discussions are accompanied by numerous figures and boxed sections, and followed by suggestions for futher reading.&lt;/p&gt;</description>
+<authors>
+<author>
+<id>3445871</id>
+<name>Andy  Clark</name>
+<role></role>
+<image_url nophoto='false'>
+<![CDATA[https://images.gr-assets.com/authors/1269856267p5/3445871.jpg]]>
+</image_url>
+<small_image_url nophoto='false'>
+<![CDATA[https://images.gr-assets.com/authors/1269856267p2/3445871.jpg]]>
+</small_image_url>
+<link><![CDATA[https://www.goodreads.com/author/show/3445871.Andy_Clark]]></link>
+<average_rating>3.89</average_rating>
+<ratings_count>992</ratings_count>
+<text_reviews_count>74</text_reviews_count>
+</author>
+</authors>
+  <published>2000</published>
+<work>  <id>282613</id>
+  <uri>kca://work/amzn1.gr.work.v1.xCZQesiWRuaIVPV6wsdFGA</uri>
+</work></book>
+
+
+  <rating>3</rating>
+  <votes>0</votes>
+  <spoiler_flag>false</spoiler_flag>
+  <spoilers_state>none</spoilers_state>
+
+
+<shelves>
+    <shelf name="read" exclusive="true" id="269274694" review_shelf_id= ""/>
+
+</shelves>
+
+  <recommended_for></recommended_for>
+  <recommended_by></recommended_by>
+  <started_at></started_at>
+  <read_at></read_at>
+  <date_added>Wed Jun 13 20:52:06 -0700 2018</date_added>
+  <date_updated>Wed Jun 13 20:52:07 -0700 2018</date_updated>
+  <read_count>1</read_count>
+  <body>Good book.</body>
+
+
+
+  <comments_count>0</comments_count>
+    <url><![CDATA[https://www.goodreads.com/review/show/67890]]></url>
+  <link><![CDATA[https://www.goodreads.com/review/show/67890]]></link>
+    <owned>0</owned>
+</review>
+
+
+</GoodreadsResponse>

--- a/spec/fixtures/review_show_by_user_and_book.xml
+++ b/spec/fixtures/review_show_by_user_and_book.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GoodreadsResponse>
+  <Request>
+    <authentication>true</authentication>
+    <key><![CDATA[SECRET_KEY]]></key>
+    <method><![CDATA[review_show_by_user_and_book]]></method>
+  </Request>
+      <review>
+  <id>21</id>
+
+  <user>
+    <id>1</id>
+    <uri>kca://profile:goodreads/A2CSQET51X1KEY</uri>
+    <name>Otis</name>
+    <display_name>Otis Chandler</display_name>
+
+    <location>San Francisco, CA</location>
+
+    <link><![CDATA[https://www.goodreads.com/user/show/1-otis-chandler]]></link>
+
+    <image_url><![CDATA[https://images.gr-assets.com/users/1506617226p3/1.jpg]]></image_url>
+    <small_image_url><![CDATA[https://images.gr-assets.com/users/1506617226p2/1.jpg]]></small_image_url>
+    <has_image>true</has_image>
+
+  </user>
+
+    <book>
+  <id type="integer">50</id>
+  <isbn>0689840926</isbn>
+  <isbn13>9780689840920</isbn13>
+  <text_reviews_count type="integer">10396</text_reviews_count>
+  <uri>kca://book/amzn1.gr.book.v1.RXVB3nJhipnhI-zLlVeRTg</uri>
+  <title>Hatchet</title>
+  <title_without_series>Hatchet</title_without_series>
+  <image_url>https://s.gr-assets.com/assets/nophoto/book/111x148-bcc042a9c91a29c1d680899eff700a03.png</image_url>
+  <small_image_url>https://s.gr-assets.com/assets/nophoto/book/50x75-a91bf249278a81aabab721ef782c4a74.png</small_image_url>
+  <large_image_url/>
+  <link>https://www.goodreads.com/book/show/50.Hatchet</link>
+  <num_pages>208</num_pages>
+  <format>Hardcover</format>
+  <edition_information/>
+  <publisher>Atheneum Books for Young Readers: Richard Jackson Books</publisher>
+  <publication_day>1</publication_day>
+  <publication_year>2000</publication_year>
+  <publication_month>4</publication_month>
+  <average_rating>3.69</average_rating>
+  <ratings_count>250763</ratings_count>
+  <description>Brian is on his way to Canada to visit his estranged father when the pilot of his small prop plane suffers a heart attack. Brian is forced to crash-land the plane in a lake--and finds himself stranded in the remote Canadian wilderness with only his clothing and the hatchet his mother gave him as a present before his departure. &lt;br /&gt;&lt;br /&gt;Brian had been distraught over his parents' impending divorce and the secret he carries about his mother, but now he is truly desolate and alone. Exhausted, terrified, and hungry, Brian struggles to find food and make a shelter for himself. He has no special knowledge of the woods, and he must find a new kind of awareness and patience as he meets each day's challenges. Is the water safe to drink? Are the berries he finds poisonous? &lt;br /&gt;&lt;br /&gt;Slowly, Brian learns to turn adversity to his advantage--an invading porcupine unexpectedly shows him how to make fire, a devastating tornado shows him how to retrieve supplies from the submerged airplane. Most of all, Brian leaves behind the self-pity he has felt about his predicament as he summons the courage to stay alive. &lt;br /&gt;&lt;br /&gt;A story of survival and of transformation, this riveting book has sparked many a reader's interest in venturing into the wild.</description>
+<authors>
+<author>
+<id>18</id>
+<name>Gary Paulsen</name>
+<role></role>
+<image_url nophoto='false'>
+<![CDATA[https://images.gr-assets.com/authors/1309159225p5/18.jpg]]>
+</image_url>
+<small_image_url nophoto='false'>
+<![CDATA[https://images.gr-assets.com/authors/1309159225p2/18.jpg]]>
+</small_image_url>
+<link><![CDATA[https://www.goodreads.com/author/show/18.Gary_Paulsen]]></link>
+<average_rating>3.76</average_rating>
+<ratings_count>399462</ratings_count>
+<text_reviews_count>28012</text_reviews_count>
+</author>
+</authors>
+  <published>2000</published>
+<work>  <id>1158125</id>
+  <uri>kca://work/amzn1.gr.work.v1.r_sm_y7tG-b00YGE5HqhQQ</uri>
+</work></book>
+
+
+    <read_statuses>
+        <read_status>
+          <id type="integer">1610038200</id>
+          <old_status></old_status>
+          <status>read</status>
+          <updated_at type="datetime">Fri Dec 09 22:55:21 -0800 2016</updated_at>
+          <ratings_count>0</ratings_count>
+          <comments_count>0</comments_count>
+        </read_status>
+    </read_statuses>
+  <rating>5</rating>
+  <votes>1</votes>
+  <spoiler_flag>false</spoiler_flag>
+  <spoilers_state>none</spoilers_state>
+
+
+<shelves>
+    <shelf name="read" exclusive="true" id="5625761" review_shelf_id= ""/>
+
+    <shelf exclusive='false' id='343477' name='childrensbooks' review_shelf_id='175' sortable='false'></shelf>
+
+    <shelf exclusive='false' id='348056' name='fiction' review_shelf_id='687' sortable='false'></shelf>
+
+    <shelf exclusive='false' id='348035' name='fiction' review_shelf_id='209' sortable='false'></shelf>
+
+</shelves>
+
+  <recommended_for></recommended_for>
+  <recommended_by></recommended_by>
+  <started_at></started_at>
+  <read_at></read_at>
+  <date_added>Tue Aug 29 11:20:01 -0700 2006</date_added>
+  <date_updated>Wed Mar 22 11:44:07 -0700 2017</date_updated>
+  <read_count>1</read_count>
+  <body>
+  </body>
+
+
+
+  <comments_count>1</comments_count>
+    <comments start="1" end="1" total="1">
+        <comment>
+  <id>161860175</id>
+  <body><![CDATA[love this book i read it in sixth grade and we had journals about it]]></body>
+
+  <user>
+    <id>64170165</id>
+    <uri>kca://profile:goodreads/A2PCDUCFEEK4OB</uri>
+    <name>Alise</name>
+    <display_name>Alise</display_name>
+
+    <location>The United States</location>
+
+    <link><![CDATA[https://www.goodreads.com/user/show/64170165-alise]]></link>
+
+    <image_url><![CDATA[https://s.gr-assets.com/assets/nophoto/user/u_111x148-9394ebedbb3c6c218f64be9549657029.png]]></image_url>
+    <small_image_url><![CDATA[https://s.gr-assets.com/assets/nophoto/user/u_50x66-632230dc9882b4352d753eedf9396530.png]]></small_image_url>
+    <has_image>false</has_image>
+
+  </user>
+
+  <created_at>Sun Jan 22 22:49:10 -0800 2017</created_at>
+  <updated_at>Sun Jan 22 22:49:10 -0800 2017</updated_at>
+</comment>
+
+    </comments>
+    <url><![CDATA[https://www.goodreads.com/review/show/21]]></url>
+  <link><![CDATA[https://www.goodreads.com/review/show/21]]></link>
+    <owned>0</owned>
+</review>
+
+
+</GoodreadsResponse>

--- a/spec/fixtures/review_update.xml
+++ b/spec/fixtures/review_update.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GoodreadsResponse>
+  <Request>
+    <authentication>true</authentication>
+    <key><![CDATA[SECRET_KEY]]></key>
+    <method><![CDATA[review_update_xml]]></method>
+  </Request>
+      <review>
+  <id>67890</id>
+
+  <user>
+    <id>123456</id>
+    <uri>kca://profile:goodreads/A25C3Y1SBGK9NK</uri>
+    <name>Test</name>
+    <display_name>Test User</display_name>
+
+    <location>Lafayette, CA</location>
+
+    <link><![CDATA[https://www.goodreads.com/user/show/123456-test-user]]></link>
+
+    <image_url><![CDATA[https://s.gr-assets.com/assets/nophoto/user/u_111x148-9394ebedbb3c6c218f64be9549657029.png]]></image_url>
+    <small_image_url><![CDATA[https://s.gr-assets.com/assets/nophoto/user/u_50x66-632230dc9882b4352d753eedf9396530.png]]></small_image_url>
+    <has_image>false</has_image>
+
+  </user>
+
+    <book>
+  <id type="integer">456</id>
+  <isbn>0195138570</isbn>
+  <isbn13>9780195138573</isbn13>
+  <text_reviews_count type="integer">11</text_reviews_count>
+  <uri>kca://book/amzn1.gr.book.v1.oHwPZrciugo6gPSINsfCaw</uri>
+  <title>Mindware: An Introduction to the Philosophy of Cognitive Science</title>
+  <title_without_series>Mindware: An Introduction to the Philosophy of Cognitive Science</title_without_series>
+  <image_url>https://s.gr-assets.com/assets/nophoto/book/111x148-bcc042a9c91a29c1d680899eff700a03.png</image_url>
+  <small_image_url>https://s.gr-assets.com/assets/nophoto/book/50x75-a91bf249278a81aabab721ef782c4a74.png</small_image_url>
+  <large_image_url/>
+  <link>https://www.goodreads.com/book/show/456.Mindware</link>
+  <num_pages>224</num_pages>
+  <format>Paperback</format>
+  <edition_information>1st edition</edition_information>
+  <publisher>Oxford University Press, USA</publisher>
+  <publication_day>21</publication_day>
+  <publication_year>2000</publication_year>
+  <publication_month>12</publication_month>
+  <average_rating>3.78</average_rating>
+  <ratings_count>210</ratings_count>
+  <description>&lt;p&gt;&lt;i&gt;Mindware&lt;/i&gt; is an introductory text with a difference. In eight short chapters it tells a story and invites the reader to join in some up-to-the-minute conceptual discussion of the key issues, problems, and opportunities in cognitive science. The story is about the search for a cognitive scientific understanding of mind. It is presented as a no-holds-barred journey from early work in Artificial Intelligence, through connectionist (artificial neural network) counter-visions, and onto neuroscience artificial life, dynamics and robotics. The journey ends with some wide-ranging and provacative speculation about the role of technology and the changing nature of the human mind itself.&lt;br /&gt;Each chapter is organized as an initial sketch of a research program or theme, followed by a substantial discussion section in which specific problems and issues (both familiear and cutting-edge) are raised and pursued. Discussion topics include mental causation, the hardware/software distinction, the relations between life and mind, the nature of perception, cognition and action, and the continuity (or otherwise) of high-level human intelligence with other forms of adaptive response. Classic topics are treated alongside the newer ones in an integrated treatment of the various discussions. The sketches and discussions are accompanied by numerous figures and boxed sections, and followed by suggestions for futher reading.&lt;/p&gt;</description>
+<authors>
+<author>
+<id>3445871</id>
+<name>Andy  Clark</name>
+<role></role>
+<image_url nophoto='false'>
+<![CDATA[https://images.gr-assets.com/authors/1269856267p5/3445871.jpg]]>
+</image_url>
+<small_image_url nophoto='false'>
+<![CDATA[https://images.gr-assets.com/authors/1269856267p2/3445871.jpg]]>
+</small_image_url>
+<link><![CDATA[https://www.goodreads.com/author/show/3445871.Andy_Clark]]></link>
+<average_rating>3.89</average_rating>
+<ratings_count>992</ratings_count>
+<text_reviews_count>74</text_reviews_count>
+</author>
+</authors>
+  <published>2000</published>
+<work>  <id>282613</id>
+  <uri>kca://work/amzn1.gr.work.v1.xCZQesiWRuaIVPV6wsdFGA</uri>
+</work></book>
+
+
+  <rating>5</rating>
+  <votes>0</votes>
+  <spoiler_flag>false</spoiler_flag>
+  <spoilers_state>none</spoilers_state>
+
+
+<shelves>
+    <shelf name="read" exclusive="true" id="269274694" review_shelf_id= ""/>
+
+</shelves>
+
+  <recommended_for></recommended_for>
+  <recommended_by></recommended_by>
+  <started_at></started_at>
+  <read_at>Fri Aug 20 00:00:00 -0700 2004</read_at>
+  <date_added>Wed Jun 13 20:52:06 -0700 2018</date_added>
+  <date_updated>Wed Jun 13 20:52:08 -0700 2018</date_updated>
+  <read_count>1</read_count>
+  <body>Fantastic book.</body>
+  <body_raw>
+
+  </body_raw>
+
+
+
+  <comments_count>0</comments_count>
+    <url><![CDATA[https://www.goodreads.com/review/show/67890]]></url>
+  <link><![CDATA[https://www.goodreads.com/review/show/67890]]></link>
+    <owned>0</owned>
+</review>
+
+
+</GoodreadsResponse>


### PR DESCRIPTION
This PR makes one change under-the-hood and introduces support for three new API methods.

The under-the-hood change is for `request` use OAuth authentication when possible. This makes all client methods more useful when dealing with Goodreads accounts with limited visibility. The change is explained in commit 4fdb51a24b445157b1cfb2f0ed3aee10ce998e17:

> Some methods (like `shelves`, which gets a user's shelves) currently use app authentication (requests that send token=SECRET_TOKEN). This works if a user is public, but if a user has restricted who can view their information you need to use `Goodreads::Request#oauth_request`. Rather than have the caller specify which to use, we can infer the desired behavior based on whether the client was instantiated with an API key or an OAuth token.

The new API methods are:

- `user_review`, which calls `/review/show_by_user_and_book.xml` to get a user's review of a book, if any exists
- `create_review`, which calls `POST /review.xml` to create a new review for a given book
- `edit_review`, which calls `POST /review/:review_id.xml` to edit a user's existing review

I attempted to add a method to delete a user's review. There is a documented API endpoint to do this, [`/review/destroy/:review_id`](https://www.goodreads.com/api/index#review.destroy), but it does not appear to work. I [posed a question](https://www.goodreads.com/topic/show/19383522) to the Goodreads Developers group but did not find any workaround.

In addition to adding unit tests for these changes, I used them to sync a database of my books with Goodreads using the following pseudocode:

```
client = Goodreads.new(oauth_token: oauth_token)
user_id = client.user_id
books.each do |book|
  existing_review = client.user_review(book.goodreads_id)
  if existing_review
    client.edit_review(existing_review.id, { read_at: ..., finished: true, ... }
  else
    client.create_review(book.goodreads_id, {read_at: ... }
  end
end
```