### PR TITLE
doc: added hakiri badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Goodreads [![Build Status](https://img.shields.io/travis/sosedoff/goodreads/master.svg)](http://travis-ci.org/sosedoff/goodreads)
+# Goodreads
+[![Build Status](https://img.shields.io/travis/sosedoff/goodreads/master.svg)](http://travis-ci.org/sosedoff/goodreads)
+[![security](https://hakiri.io/github/sosedoff/goodreads/master.svg)](https://hakiri.io/github/sosedoff/goodreads/master)
 
 Ruby wrapper to communicate with Goodreads API.
 


### PR DESCRIPTION
Add Hakiri badge to track security warnings. Note Hakiri requires authorization to [generate the badge](https://hakiri.io/pricing).

Also added line-breaks for readability (especially with diffs).