### PR TITLE
doc: added coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Goodreads [![Build Status](https://img.shields.io/travis/sosedoff/goodreads/master.svg)](http://travis-ci.org/sosedoff/goodreads)
+# Goodreads
+[![Build Status](https://img.shields.io/travis/sosedoff/goodreads/master.svg)](http://travis-ci.org/sosedoff/goodreads)
+[![Coverage Status](https://coveralls.io/repos/github/sosedoff/goodreads/badge.svg?branch=master)](https://coveralls.io/github/sosedoff/goodreads?branch=master)
 
 Ruby wrapper to communicate with Goodreads API.
 

--- a/goodreads.gemspec
+++ b/goodreads.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.email       = ["dan.sosedoff@gmail.com"]
   spec.license     = "MIT"
 
+  spec.add_development_dependency 'coveralls', '>= 0'
   spec.add_development_dependency "webmock",   "~> 2.0"
   spec.add_development_dependency "rake",      "~> 10"
   spec.add_development_dependency "rspec",     "~> 2.12"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
+require 'coveralls'
+Coveralls.wear!
 require "simplecov"
 
 SimpleCov.start do


### PR DESCRIPTION
Added [Coveralls badge](
https://github.com/ivanoblomov/goodreads/tree/coveralls#goodreads) to track code coverage. Note it requires [authorizing Coveralls to access your repo](https://docs.coveralls.io).

Also added line-breaks for readability (especially with diffs).