### PR TITLE
doc: added inch-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Goodreads [![Build Status](https://img.shields.io/travis/sosedoff/goodreads/master.svg)](http://travis-ci.org/sosedoff/goodreads)
+# Goodreads
+[![Build Status](https://img.shields.io/travis/sosedoff/goodreads/master.svg)](http://travis-ci.org/sosedoff/goodreads)
+[![Inline docs](http://inch-ci.org/github/sosedoff/goodreads.svg?branch=master)](http://inch-ci.org/github/sosedoff/goodreads)
 
 Ruby wrapper to communicate with Goodreads API.
 


### PR DESCRIPTION
Added [Inch CI badge](
https://github.com/ivanoblomov/goodreads/tree/inch-ci) to track [documentation coverage](https://inch-ci.org/github/sosedoff/goodreads). Also added line-breaks for readability (especially with diffs).