### PR TITLE
goodreads: Handle response codes exhaustively

### DIFF
--- a/lib/goodreads/errors.rb
+++ b/lib/goodreads/errors.rb
@@ -4,4 +4,6 @@ module Goodreads
   class Forbidden < Error; end
   class Unauthorized < Error; end
   class NotFound < Error; end
+  class ServerError < Error; end
+  class UnknownError < Error; end
 end

--- a/lib/goodreads/request.rb
+++ b/lib/goodreads/request.rb
@@ -46,6 +46,10 @@ module Goodreads
           fail(Goodreads::Forbidden)
         when 404
           fail(Goodreads::NotFound)
+        when 500..599
+          fail(Goodreads::ServerError.new(response.code))
+        else
+          fail(Goodreads::UnknownError.new(response.code))
         end
       end
 


### PR DESCRIPTION
The Goodreads `user.show` API has been flaky recently, returning 500s.

The Ruby bindings weren't catching the `5xx` error range, causing the (empty) error response body to fall through to response handling and consequently fail on XML parsing.

This PR fixes this specific case (the `5xx` range) by adding `Goodreads::ServerError` and more generally fixes the behavior of `http_request` by making it exhaustive with `Goodreads::UnknownError` for all unknown response codes.

Please let me know if there's anything else I can add!