### PR TITLE
README: Note Goodread's API retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ruby wrapper to communicate with Goodreads API.
 
+**NOTE: The Goodreads API [is being discontinued](https://www.goodreads.com/api).**
+
 ## Requirements
 
 - Ruby 1.9.3+


### PR DESCRIPTION
Goodreads has officially announced that they're retiring their public API: https://www.goodreads.com/api

They've been unconditionally disabling "inactive" (meaning not used in the last 30 days) keys for the last couple of weeks. They haven't announced a specific shut-off date yet, but I figured that it makes sense to warn potential new consumers of this wrapper that it won't be around for long.