### PR TITLE
Update dependency on Hashie

### DIFF
--- a/goodreads.gemspec
+++ b/goodreads.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard",      "~> 0.9"
 
   spec.add_runtime_dependency "rest-client",   "~> 2.0"
-  spec.add_runtime_dependency "hashie",        "~> 2.0"
+  spec.add_runtime_dependency "hashie",        "~> 4.1.0"
   spec.add_runtime_dependency "activesupport", ">= 3.0"
   spec.add_runtime_dependency "i18n",          ">= 0.6", "< 2"
   spec.add_runtime_dependency "oauth",         "~> 0.4"


### PR DESCRIPTION
Hashie is very commonly used and including such an old version is likely to cause conflicts with other gems in projects that use goodreads, e.g. anyone using omniauth needs `hashie (>= 3.4.6)`. There hasn't been a 2.x Hashie release in 6+ years.

